### PR TITLE
ci: add path-based change detection to skip unaffected CI jobs

### DIFF
--- a/.github/agents/create-pr.agent.md
+++ b/.github/agents/create-pr.agent.md
@@ -8,16 +8,16 @@ You are a GitHub PR creation specialist for this repository. Your job is to crea
 
 ## Constraints
 
-- NEVER skip or rewrite template sections — fill every section, use `N/A` or `NONE` for inapplicable ones
+- NEVER skip or rewrite template sections - fill every section, use `N/A` or `NONE` for inapplicable ones
 - NEVER create the PR before showing the full body to the user, unless they explicitly waive preview
 - ALWAYS write PR title and body in English
-- ONLY use `gh` CLI for PR operations — never use the GitHub API directly
-- DO NOT modify code or make commits — only create the PR for what's already committed
+- ONLY use `gh` CLI for PR operations - never use the GitHub API directly
+- DO NOT modify code or make commits - only create the PR for what's already committed
 - **Labels are required by branch protection and MUST be included in every `gh pr create` call:**
   - Exactly one `type/*` label: `type/feature`, `type/fix`, `type/docs`, `type/chore`, `type/refactor`, `type/performance`, `type/test`
   - At least one `area/*` label: `area/server`, `area/agent`, `area/frontend`, `area/proto`, `area/docs`, `area/ci`
   - Optional `impact/*` labels when relevant: `impact/breaking`, `impact/security`, `impact/ops`
-  - Always use `--label` for each label — a PR without `type/*` + `area/*` cannot be merged
+  - Always use `--label` for each label - a PR without `type/*` + `area/*` cannot be merged
 
 ## Workflow
 
@@ -45,26 +45,45 @@ You are a GitHub PR creation specialist for this repository. Your job is to crea
    - Set release-note to `NONE` for internal/CI/refactoring changes; describe user-facing changes
    - Check all applicable checklist items
 
-6. **Preview**: Show the full rendered PR body in chat. Ask for confirmation before creating. Skip this step only if the user explicitly said to skip preview.
+6. **Preflight before create**:
+   - Disable pagers for all `gh` reads to avoid interactive alternate-buffer behavior:
+   ```bash
+   export GH_PAGER=cat
+   export PAGER=cat
+   ```
+   - Check if a PR already exists for `head -> base` before running `gh pr create`:
+   ```bash
+   existing_pr_url="$(gh pr list --state open --head <head> --base <base> --json url --jq '.[0].url')"
+   ```
+   - If `existing_pr_url` is not empty, do **not** run `gh pr create` again. Report the existing URL and, if needed, update with:
+   ```bash
+   gh pr edit <number-or-url> --title "<title>" --body-file "$pr_body_file" \
+     --add-label "type/chore" --add-label "area/ci"
+   ```
 
-7. **Create the PR** (always include at least one `--label type/*` and one `--label area/*`):
+7. **Preview**: Show the full rendered PR body in chat. Ask for confirmation before creating. Skip this step only if the user explicitly said to skip preview.
+
+8. **Create or update PR** (always include at least one `--label type/*` and one `--label area/*`):
+   - Use a **two-command** approach in terminal agents: first write the body file, then run `gh pr create` separately.
+   - Do not combine a long heredoc and `gh pr create` in one giant command.
    ```bash
    pr_body_file="$(mktemp /tmp/gh-pr-body-XXXXXX.md)"
    cat > "$pr_body_file" <<'PREOF'
    ...filled body...
    PREOF
+   test -s "$pr_body_file"
    gh pr create --base <base> --head <head> --title "<title>" --body-file "$pr_body_file" \
      --label "type/feature" --label "area/server"
    rm -f "$pr_body_file"
    ```
 
-8. **Report**: Show the created PR URL with a summary of title, base, head, and any follow-ups needed.
+9. **Report**: Show the created or existing PR URL with a summary of title, base, head, and any follow-ups needed.
 
 ## Label Selection
 
 Choose the `type/*` label based on the primary reason the PR exists:
 
-| If the PR primarily… | Use |
+| If the PR primarily... | Use |
 |---|---|
 | Adds a new user-visible capability | `type/feature` |
 | Corrects wrong behaviour | `type/fix` |
@@ -95,5 +114,10 @@ Choose `area/*` labels from the files changed (use multiple if needed).
 
 Always end with:
 - The PR URL
-- One-line summary: `<title> (base ← head)`
+- One-line summary: `<title> (base <- head)`
 - Any required follow-up actions
+
+## Reliability Notes
+
+- If terminal output suggests only heredoc lines were processed and no `gh pr create` output appears, immediately run `gh pr create` as a separate command.
+- If `gh pr create` says a PR already exists, treat that as success for creation intent and switch to verify/update mode.

--- a/.github/skills/gh-create-pr/SKILL.md
+++ b/.github/skills/gh-create-pr/SKILL.md
@@ -17,17 +17,33 @@ description: Create or update GitHub pull requests using the repository-required
 4. Determine the base branch:
    - Default base is `main`. Ask the user to confirm if a different base is needed.
    - Check available remotes with `git remote -v` if unclear.
-5. Create a temp file and write the PR body:
+5. Preflight before creating:
+   - Disable pager to prevent interactive alternate-buffer output from `gh`:
+   ```bash
+   export GH_PAGER=cat
+   export PAGER=cat
+   ```
+   - Check for an existing open PR for `head -> base`:
+   ```bash
+   existing_pr_url="$(gh pr list --state open --head <head> --base <base> --json url --jq '.[0].url')"
+   ```
+   - If found, do not call `gh pr create` again. Report the existing PR URL and use `gh pr edit` when updates are requested.
+6. Create a temp file and write the PR body:
    - Use `pr_body_file="$(mktemp /tmp/gh-pr-body-XXXXXX).md"`
    - Fill content using the template structure exactly (keep section order, headings, checkbox formatting).
    - If not applicable, write `N/A` or `None`.
-6. Preview the temp file content. **Show the file path** (e.g., `/tmp/gh-pr-body-XXXXXX.md`) and ask for explicit confirmation before creating. **Skip this step if the user explicitly indicates no preview/confirmation is needed** (for example, automation workflows).
-7. After confirmation, create the PR:
+   - In terminal-agent execution, do not chain a long heredoc and `gh pr create` in one command; run them as separate commands.
+   - Validate the body file exists and is non-empty before create:
+   ```bash
+   test -s "$pr_body_file"
+   ```
+7. Preview the temp file content. **Show the file path** (e.g., `/tmp/gh-pr-body-XXXXXX.md`) and ask for explicit confirmation before creating. **Skip this step if the user explicitly indicates no preview/confirmation is needed** (for example, automation workflows).
+8. After confirmation, create the PR:
    ```bash
    gh pr create --base <base> --head <head> --title "<title>" --body-file "$pr_body_file"
    ```
-8. Clean up the temp file: `rm -f "$pr_body_file"`
-9. Report the created PR URL and summarize title/base/head and any required follow-up.
+9. Clean up the temp file: `rm -f "$pr_body_file"`
+10. Report the created or existing PR URL and summarize title/base/head and any required follow-up.
 
 ## Constraints
 
@@ -42,7 +58,7 @@ description: Create or update GitHub pull requests using the repository-required
   - At least one `area/*` label (`area/server`, `area/agent`, `area/frontend`, `area/proto`, `area/docs`, `area/ci`)
   - Optional `impact/*` labels (`impact/breaking`, `impact/security`, `impact/ops`) when relevant
   - Use `--label` for each label when calling `gh pr create`
-- **Release note & Documentation checkbox** — both are driven by whether the change is **user-facing**. Use the table below:
+- **Release note & Documentation checkbox** - both are driven by whether the change is **user-facing**. Use the table below:
 
   | Change type | `type/*` label | Release note | Docs `[x]` |
   |---|---|---|---|
@@ -63,11 +79,27 @@ description: Create or update GitHub pull requests using the repository-required
 # read template
 cat .github/pull_request_template.md
 
+# avoid gh pager TUI behavior in non-interactive runs
+export GH_PAGER=cat
+export PAGER=cat
+
+# check for existing open PR on this branch pair first
+existing_pr_url="$(gh pr list --state open --head <head> --base <base> --json url --jq '.[0].url')"
+if [[ -n "$existing_pr_url" ]]; then
+  echo "Existing PR: $existing_pr_url"
+  # optional update path:
+  # gh pr edit "$existing_pr_url" --title "<title>" --body-file "$pr_body_file" --add-label "type/chore" --add-label "area/ci"
+  exit 0
+fi
+
 # show this full Markdown body in chat first
 pr_body_file="$(mktemp /tmp/gh-pr-body-XXXXXX).md"
-cat > "$pr_body_file" <<'EOF'
+cat > "$pr_body_file" <<'EOF2'
 ...filled template body...
-EOF
+EOF2
+
+# validate body file was written before create
+test -s "$pr_body_file"
 
 # run only after explicit user confirmation
 # always include at least one --label type/* and one --label area/*
@@ -75,3 +107,12 @@ gh pr create --base <base> --head <head> --title "<title>" --body-file "$pr_body
   --label "type/feature" --label "area/server"
 rm -f "$pr_body_file"
 ```
+
+## Troubleshooting
+
+- Symptom: terminal output shows only heredoc lines and no `gh pr create` result.
+  - Cause: long chained command got cut or never reached the `gh` segment.
+  - Fix: run `gh pr create ...` as a separate command using the already-written body file.
+- Symptom: `gh pr create` returns "a pull request for branch ... already exists".
+  - Meaning: no creation failure; PR already exists.
+  - Fix: report that URL, verify title/base/head/labels with `gh pr view`, and use `gh pr edit` only if updates are needed.

--- a/.github/skills/gh-create-pr/agents/openai.yaml
+++ b/.github/skills/gh-create-pr/agents/openai.yaml
@@ -1,4 +1,25 @@
 interface:
   display_name: "Create GitHub PR"
-  short_description: "Create PRs with required template compliance"
-  default_prompt: "Create a pull request for my current branch using the repository template workflow."
+  short_description: "Create or update PRs with required template and labels"
+  default_prompt: |
+    Create or update a pull request for my current branch using the repository template workflow.
+
+    Reliability requirements:
+    - Read .github/pull_request_template.md first and preserve all sections.
+    - Determine base/head from current branch context (default base: main unless user says otherwise).
+    - Before creating, run preflight checks:
+      1) export GH_PAGER=cat and export PAGER=cat
+      2) detect existing open PR for head->base with:
+         gh pr list --state open --head <head> --base <base> --json url --jq '.[0].url'
+      3) if an existing PR is found, do not run gh pr create again; report URL and use gh pr edit if updates are needed.
+    - Show the full PR body in chat and request confirmation before creation unless the user explicitly waives preview.
+    - Use a two-step create flow in terminal agents:
+      1) write body to a temp file
+      2) run gh pr create as a separate command
+      Do not chain a long heredoc and gh pr create in one command.
+    - Validate body file exists before create: test -s "$pr_body_file"
+    - Always include required labels in gh pr create:
+      - exactly one type/*
+      - at least one area/*
+      - optional impact/* when relevant
+    - If gh pr create reports "already exists", treat that as success for creation intent and switch to verify/update mode.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,66 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+      agent: ${{ steps.filter.outputs.agent }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      proto: ${{ steps.filter.outputs.proto }}
+      go: ${{ steps.filter.outputs.go }}
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            server:
+              - 'server/**'
+              - 'proto/**'
+              - '.github/workflows/**'
+              - '.golangci.yml'
+              - 'justfile'
+            agent:
+              - 'agent/**'
+              - 'proto/**'
+              - '.github/workflows/**'
+              - '.golangci.yml'
+              - 'justfile'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/**'
+            proto:
+              - 'proto/**'
+              - '.github/workflows/**'
+            go:
+              - 'server/**'
+              - 'agent/**'
+              - 'proto/**'
+              - '.github/workflows/**'
+              - '.golangci.yml'
+              - 'justfile'
+            build:
+              - 'server/**'
+              - 'agent/**'
+              - 'frontend/**'
+              - 'proto/**'
+              - '.github/workflows/**'
+              - 'docker/**'
+              - 'justfile'
+
   # ── Go: server tests ────────────────────────────────────────────────────────
   test-server:
     name: Test (server)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.server == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -45,6 +101,8 @@ jobs:
   test-agent:
     name: Test (agent)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.agent == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -74,6 +132,8 @@ jobs:
   test-frontend:
     name: Test (frontend)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -92,6 +152,8 @@ jobs:
   fmt-vet:
     name: fmt + vet
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -145,6 +207,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.build == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -191,7 +255,8 @@ jobs:
   lint:
     name: Lint (golangci-lint)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -235,7 +300,8 @@ jobs:
   proto-check:
     name: Proto (lint + breaking)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.proto == 'true'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -1,7 +1,7 @@
 name: PR Label Check
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   validate-labels:
-    name: Validate required labels
+    name: PR Label Check
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR labels

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,17 +3,14 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-  # Re-running on PR events keeps the "next version" suggestion current
-  # as PRs are opened/labeled, which helps maintainers decide the bump
-  # before they create the actual release.
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   update-draft:
+    name: Release Drafter
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### What this PR does

PR title reminder (non-blocking): use a short, imperative, specific title. With squash merge, this title becomes the merge commit subject.

Optional maintainer hint for squash subject:

Suggested squash subject: chore(ci): add path-based change detection for jobs

Reference: [docs/maintainer-guidelines.md](docs/maintainer-guidelines.md)

Before this PR:
- CI jobs ran broadly on pull requests even when unrelated parts of the repository changed.
- This increased CI runtime and resource usage for small or scoped changes.

After this PR:
- A new Detect changes job computes path-based change flags.
- Server, agent, frontend, Go fmt/vet, build, lint, and proto jobs are conditionally executed on pull requests only when relevant paths changed.
- Non-pull request events continue to run the full pipeline as before.

Fixes #
N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added a dedicated upfront job and job dependencies to reduce unnecessary downstream job executions on pull requests.
- Included shared trigger paths like proto, workflow files, justfile, and golangci config to avoid under-triggering critical checks.

The following alternatives were considered:
- Keep running all jobs on every pull request for simplicity, but that keeps CI cost/time high.
- Use per-job inlined path checks only, but centralizing change detection is easier to maintain and reason about.

Links to places where the discussion took place: N/A

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- This change only affects CI workflow execution conditions.
- Workflow logic was updated in `.github/workflows/ci.yml`.

### Labels

Please ensure this PR has:

- exactly one `type/*` label
- one or more `area/*` labels when relevant
- optional `impact/*` labels when they help release context

Type label guidance:

- choose the label that best matches the main reason this PR exists
- if a feature PR also includes docs/tests/refactors, keep `type/feature`
- if the main goal is efficiency, prefer `type/performance` over `type/refactor`

Reference: [docs/release-workflow-plan.md](docs/release-workflow-plan.md)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others
- [x] Labels: This PR has exactly one `type/*` label and appropriate `area/*` labels

### Release note

```release-note
NONE
```
