### PR TITLE
Improve agent docs and add Dependabot skill references

### DIFF
--- a/.github/skills/create-agentsmd/SKILL.md
+++ b/.github/skills/create-agentsmd/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: create-agentsmd
+description: 'Prompt for generating an AGENTS.md file for a repository'
+---
+
+# Create high‑quality AGENTS.md file
+
+You are a code agent. Your task is to create a complete, accurate AGENTS.md at the root of this repository that follows the public guidance at https://agents.md/.
+
+AGENTS.md is an open format designed to provide coding agents with the context and instructions they need to work effectively on a project.
+
+## What is AGENTS.md?
+
+AGENTS.md is a Markdown file that serves as a "README for agents" - a dedicated, predictable place to provide context and instructions to help AI coding agents work on your project. It complements README.md by containing detailed technical context that coding agents need but might clutter a human-focused README.
+
+## Key Principles
+
+- **Agent-focused**: Contains detailed technical instructions for automated tools
+- **Complements README.md**: Doesn't replace human documentation but adds agent-specific context
+- **Standardized location**: Placed at repository root (or subproject roots for monorepos)
+- **Open format**: Uses standard Markdown with flexible structure
+- **Ecosystem compatibility**: Works across 20+ different AI coding tools and agents
+
+## File Structure and Content Guidelines
+
+### 1. Required Setup
+
+- Create the file as `AGENTS.md` in the repository root
+- Use standard Markdown formatting
+- No required fields - flexible structure based on project needs
+
+### 2. Essential Sections to Include
+
+#### Project Overview
+
+- Brief description of what the project does
+- Architecture overview if complex
+- Key technologies and frameworks used
+
+#### Setup Commands
+
+- Installation instructions
+- Environment setup steps
+- Dependency management commands
+- Database setup if applicable
+
+#### Development Workflow
+
+- How to start development server
+- Build commands
+- Watch/hot-reload setup
+- Package manager specifics (npm, pnpm, yarn, etc.)
+
+#### Testing Instructions
+
+- How to run tests (unit, integration, e2e)
+- Test file locations and naming conventions
+- Coverage requirements
+- Specific test patterns or frameworks used
+- How to run subset of tests or focus on specific areas
+
+#### Code Style Guidelines
+
+- Language-specific conventions
+- Linting and formatting rules
+- File organization patterns
+- Naming conventions
+- Import/export patterns
+
+#### Build and Deployment
+
+- Build commands and outputs
+- Environment configurations
+- Deployment steps and requirements
+- CI/CD pipeline information
+
+### 3. Optional but Recommended Sections
+
+#### Security Considerations
+
+- Security testing requirements
+- Secrets management
+- Authentication patterns
+- Permission models
+
+#### Monorepo Instructions (if applicable)
+
+- How to work with multiple packages
+- Cross-package dependencies
+- Selective building/testing
+- Package-specific commands
+
+#### Pull Request Guidelines
+
+- Title format requirements
+- Required checks before submission
+- Review process
+- Commit message conventions
+
+#### Debugging and Troubleshooting
+
+- Common issues and solutions
+- Logging patterns
+- Debug configuration
+- Performance considerations
+
+## Example Template
+
+Use this as a starting template and customize based on the specific project:
+
+```markdown
+# AGENTS.md
+
+## Project Overview
+
+[Brief description of the project, its purpose, and key technologies]
+
+## Setup Commands
+
+- Install dependencies: `[package manager] install`
+- Start development server: `[command]`
+- Build for production: `[command]`
+
+## Development Workflow
+
+- [Development server startup instructions]
+- [Hot reload/watch mode information]
+- [Environment variable setup]
+
+## Testing Instructions
+
+- Run all tests: `[command]`
+- Run unit tests: `[command]`
+- Run integration tests: `[command]`
+- Test coverage: `[command]`
+- [Specific testing patterns or requirements]
+
+## Code Style
+
+- [Language and framework conventions]
+- [Linting rules and commands]
+- [Formatting requirements]
+- [File organization patterns]
+
+## Build and Deployment
+
+- [Build process details]
+- [Output directories]
+- [Environment-specific builds]
+- [Deployment commands]
+
+## Pull Request Guidelines
+
+- Title format: [component] Brief description
+- Required checks: `[lint command]`, `[test command]`
+- [Review requirements]
+
+## Additional Notes
+
+- [Any project-specific context]
+- [Common gotchas or troubleshooting tips]
+- [Performance considerations]
+```
+
+## Working Example from agents.md
+
+Here's a real example from the agents.md website:
+
+```markdown
+# Sample AGENTS.md file
+
+## Dev environment tips
+
+- Use `pnpm dlx turbo run where <project_name>` to jump to a package instead of scanning with `ls`.
+- Run `pnpm install --filter <project_name>` to add the package to your workspace so Vite, ESLint, and TypeScript can see it.
+- Use `pnpm create vite@latest <project_name> -- --template react-ts` to spin up a new React + Vite package with TypeScript checks ready.
+- Check the name field inside each package's package.json to confirm the right name—skip the top-level one.
+
+## Testing instructions
+
+- Find the CI plan in the .github/workflows folder.
+- Run `pnpm turbo run test --filter <project_name>` to run every check defined for that package.
+- From the package root you can just call `pnpm test`. The commit should pass all tests before you merge.
+- To focus on one step, add the Vitest pattern: `pnpm vitest run -t "<test name>"`.
+- Fix any test or type errors until the whole suite is green.
+- After moving files or changing imports, run `pnpm lint --filter <project_name>` to be sure ESLint and TypeScript rules still pass.
+- Add or update tests for the code you change, even if nobody asked.
+
+## PR instructions
+
+- Title format: [<project_name>] <Title>
+- Always run `pnpm lint` and `pnpm test` before committing.
+```
+
+## Implementation Steps
+
+1. **Analyze the project structure** to understand:
+
+   - Programming languages and frameworks used
+   - Package managers and build tools
+   - Testing frameworks
+   - Project architecture (monorepo, single package, etc.)
+
+2. **Identify key workflows** by examining:
+
+   - package.json scripts
+   - Makefile or other build files
+   - CI/CD configuration files
+   - Documentation files
+
+3. **Create comprehensive sections** covering:
+
+   - All essential setup and development commands
+   - Testing strategies and commands
+   - Code style and conventions
+   - Build and deployment processes
+
+4. **Include specific, actionable commands** that agents can execute directly
+
+5. **Test the instructions** by ensuring all commands work as documented
+
+6. **Keep it focused** on what agents need to know, not general project information
+
+## Best Practices
+
+- **Be specific**: Include exact commands, not vague descriptions
+- **Use code blocks**: Wrap commands in backticks for clarity
+- **Include context**: Explain why certain steps are needed
+- **Stay current**: Update as the project evolves
+- **Test commands**: Ensure all listed commands actually work
+- **Consider nested files**: For monorepos, create AGENTS.md files in subprojects as needed
+
+## Monorepo Considerations
+
+For large monorepos:
+
+- Place a main AGENTS.md at the repository root
+- Create additional AGENTS.md files in subproject directories
+- The closest AGENTS.md file takes precedence for any given location
+- Include navigation tips between packages/projects
+
+## Final Notes
+
+- AGENTS.md works with 20+ AI coding tools including Cursor, Aider, Gemini CLI, and many others
+- The format is intentionally flexible - adapt it to your project's needs
+- Focus on actionable instructions that help agents understand and work with your codebase
+- This is living documentation - update it as your project evolves
+
+When creating the AGENTS.md file, prioritize clarity, completeness, and actionability. The goal is to give any coding agent enough context to effectively contribute to the project without requiring additional human guidance.

--- a/.github/skills/create-github-action-workflow-specification/SKILL.md
+++ b/.github/skills/create-github-action-workflow-specification/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: create-github-action-workflow-specification
+description: 'Create a formal specification for an existing GitHub Actions CI/CD workflow, optimized for AI consumption and workflow maintenance.'
+---
+
+# Create GitHub Actions Workflow Specification
+
+Create a comprehensive specification for the GitHub Actions workflow: `${input:WorkflowFile}`.
+
+This specification serves as a specification for the workflow's behavior, requirements, and constraints. It must be implementation-agnostic, focusing on **what** the workflow accomplishes rather than **how** it's implemented.
+
+## AI-Optimized Requirements
+
+- **Token Efficiency**: Use concise language without sacrificing clarity
+- **Structured Data**: Leverage tables, lists, and diagrams for dense information
+- **Semantic Clarity**: Use precise terminology consistently throughout
+- **Implementation Abstraction**: Avoid specific syntax, commands, or tool versions
+- **Maintainability**: Design for easy updates as workflow evolves
+
+## Specification Template
+
+Save as: `/spec/spec-process-cicd-[workflow-name].md`
+
+```md
+---
+title: CI/CD Workflow Specification - [Workflow Name]
+version: 1.0
+date_created: [YYYY-MM-DD]
+last_updated: [YYYY-MM-DD]
+owner: DevOps Team
+tags: [process, cicd, github-actions, automation, [domain-specific-tags]]
+---
+
+## Workflow Overview
+
+**Purpose**: [One sentence describing workflow's primary goal]
+**Trigger Events**: [List trigger conditions]
+**Target Environments**: [Environment scope]
+
+## Execution Flow Diagram
+
+```mermaid
+graph TD
+    A[Trigger Event] --> B[Job 1]
+    B --> C[Job 2]
+    C --> D[Job 3]
+    D --> E[End]
+    
+    B --> F[Parallel Job]
+    F --> D
+    
+    style A fill:#e1f5fe
+    style E fill:#e8f5e8
+```
+
+## Jobs & Dependencies
+
+| Job Name | Purpose | Dependencies | Execution Context |
+|----------|---------|--------------|-------------------|
+| job-1 | [Purpose] | [Prerequisites] | [Runner/Environment] |
+| job-2 | [Purpose] | job-1 | [Runner/Environment] |
+
+## Requirements Matrix
+
+### Functional Requirements
+| ID | Requirement | Priority | Acceptance Criteria |
+|----|-------------|----------|-------------------|
+| REQ-001 | [Requirement] | High | [Testable criteria] |
+| REQ-002 | [Requirement] | Medium | [Testable criteria] |
+
+### Security Requirements
+| ID | Requirement | Implementation Constraint |
+|----|-------------|---------------------------|
+| SEC-001 | [Security requirement] | [Constraint description] |
+
+### Performance Requirements
+| ID | Metric | Target | Measurement Method |
+|----|-------|--------|-------------------|
+| PERF-001 | [Metric] | [Target value] | [How measured] |
+
+## Input/Output Contracts
+
+### Inputs
+
+```yaml
+# Environment Variables
+ENV_VAR_1: string  # Purpose: [description]
+ENV_VAR_2: secret  # Purpose: [description]
+
+# Repository Triggers
+paths: [list of path filters]
+branches: [list of branch patterns]
+```
+
+### Outputs
+
+```yaml
+# Job Outputs
+job_1_output: string  # Description: [purpose]
+build_artifact: file  # Description: [content type]
+```
+
+### Secrets & Variables
+
+| Type | Name | Purpose | Scope |
+|------|------|---------|-------|
+| Secret | SECRET_1 | [Purpose] | Workflow |
+| Variable | VAR_1 | [Purpose] | Repository |
+
+## Execution Constraints
+
+### Runtime Constraints
+
+- **Timeout**: [Maximum execution time]
+- **Concurrency**: [Parallel execution limits]
+- **Resource Limits**: [Memory/CPU constraints]
+
+### Environmental Constraints
+
+- **Runner Requirements**: [OS/hardware needs]
+- **Network Access**: [External connectivity needs]
+- **Permissions**: [Required access levels]
+
+## Error Handling Strategy
+
+| Error Type | Response | Recovery Action |
+|------------|----------|-----------------|
+| Build Failure | [Response] | [Recovery steps] |
+| Test Failure | [Response] | [Recovery steps] |
+| Deployment Failure | [Response] | [Recovery steps] |
+
+## Quality Gates
+
+### Gate Definitions
+
+| Gate | Criteria | Bypass Conditions |
+|------|----------|-------------------|
+| Code Quality | [Standards] | [When allowed] |
+| Security Scan | [Thresholds] | [When allowed] |
+| Test Coverage | [Percentage] | [When allowed] |
+
+## Monitoring & Observability
+
+### Key Metrics
+
+- **Success Rate**: [Target percentage]
+- **Execution Time**: [Target duration]
+- **Resource Usage**: [Monitoring approach]
+
+### Alerting
+
+| Condition | Severity | Notification Target |
+|-----------|----------|-------------------|
+| [Condition] | [Level] | [Who/Where] |
+
+## Integration Points
+
+### External Systems
+
+| System | Integration Type | Data Exchange | SLA Requirements |
+|--------|------------------|---------------|------------------|
+| [System] | [Type] | [Data format] | [Requirements] |
+
+### Dependent Workflows
+
+| Workflow | Relationship | Trigger Mechanism |
+|----------|--------------|-------------------|
+| [Workflow] | [Type] | [How triggered] |
+
+## Compliance & Governance
+
+### Audit Requirements
+
+- **Execution Logs**: [Retention policy]
+- **Approval Gates**: [Required approvals]
+- **Change Control**: [Update process]
+
+### Security Controls
+
+- **Access Control**: [Permission model]
+- **Secret Management**: [Rotation policy]
+- **Vulnerability Scanning**: [Scan frequency]
+
+## Edge Cases & Exceptions
+
+### Scenario Matrix
+
+| Scenario | Expected Behavior | Validation Method |
+|----------|-------------------|-------------------|
+| [Edge case] | [Behavior] | [How to verify] |
+
+## Validation Criteria
+
+### Workflow Validation
+
+- **VLD-001**: [Validation rule]
+- **VLD-002**: [Validation rule]
+
+### Performance Benchmarks
+
+- **PERF-001**: [Benchmark criteria]
+- **PERF-002**: [Benchmark criteria]
+
+## Change Management
+
+### Update Process
+
+1. **Specification Update**: Modify this document first
+2. **Review & Approval**: [Approval process]
+3. **Implementation**: Apply changes to workflow
+4. **Testing**: [Validation approach]
+5. **Deployment**: [Release process]
+
+### Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | [Date] | Initial specification | [Author] |
+
+## Related Specifications
+
+- [Link to related workflow specs]
+- [Link to infrastructure specs]
+- [Link to deployment specs]
+
+```
+
+## Analysis Instructions
+
+When analyzing the workflow file:
+
+1. **Extract Core Purpose**: Identify the primary business objective
+2. **Map Job Flow**: Create dependency graph showing execution order
+3. **Identify Contracts**: Document inputs, outputs, and interfaces
+4. **Capture Constraints**: Extract timeouts, permissions, and limits
+5. **Define Quality Gates**: Identify validation and approval points
+6. **Document Error Paths**: Map failure scenarios and recovery
+7. **Abstract Implementation**: Focus on behavior, not syntax
+
+## Mermaid Diagram Guidelines
+
+### Flow Types
+- **Sequential**: `A --> B --> C`
+- **Parallel**: `A --> B & A --> C; B --> D & C --> D`
+- **Conditional**: `A --> B{Decision}; B -->|Yes| C; B -->|No| D`
+
+### Styling
+```mermaid
+style TriggerNode fill:#e1f5fe
+style SuccessNode fill:#e8f5e8
+style FailureNode fill:#ffebee
+style ProcessNode fill:#f3e5f5
+```
+
+### Complex Workflows
+For workflows with 5+ jobs, use subgraphs:
+```mermaid
+graph TD
+    subgraph "Build Phase"
+        A[Lint] --> B[Test] --> C[Build]
+    end
+    subgraph "Deploy Phase"  
+        D[Staging] --> E[Production]
+    end
+    C --> D
+```
+
+## Token Optimization Strategies
+
+1. **Use Tables**: Dense information in structured format
+2. **Abbreviate Consistently**: Define once, use throughout
+3. **Bullet Points**: Avoid prose paragraphs
+4. **Code Blocks**: Structured data over narrative
+5. **Cross-Reference**: Link instead of repeat information
+
+Focus on creating a specification that serves as both documentation and a template for workflow updates.

--- a/.github/skills/create-github-issues-feature-from-implementation-plan/SKILL.md
+++ b/.github/skills/create-github-issues-feature-from-implementation-plan/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: create-github-issues-feature-from-implementation-plan
+description: 'Create GitHub Issues from implementation plan phases using feature_request.yml or chore_request.yml templates.'
+---
+
+# Create GitHub Issue from Implementation Plan
+
+Create GitHub Issues for the implementation plan at `${file}`.
+
+## Process
+
+1. Analyze plan file to identify phases
+2. Check existing issues using `search_issues`
+3. Create new issue per phase using `create_issue` or update existing with `update_issue`
+4. Use `feature_request.yml` or `chore_request.yml` templates (fallback to default)
+
+## Requirements
+
+- One issue per implementation phase
+- Clear, structured titles and descriptions
+- Include only changes required by the plan
+- Verify against existing issues before creation
+
+## Issue Content
+
+- Title: Phase name from implementation plan
+- Description: Phase details, requirements, and context
+- Labels: Appropriate for issue type (feature/chore)

--- a/.github/skills/create-implementation-plan/SKILL.md
+++ b/.github/skills/create-implementation-plan/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: create-implementation-plan
+description: 'Create a new implementation plan file for new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.'
+---
+
+# Create Implementation Plan
+
+## Primary Directive
+
+Your goal is to create a new implementation plan file for `${input:PlanPurpose}`. Your output must be machine-readable, deterministic, and structured for autonomous execution by other AI systems or humans.
+
+## Execution Context
+
+This prompt is designed for AI-to-AI communication and automated processing. All instructions must be interpreted literally and executed systematically without human interpretation or clarification.
+
+## Core Requirements
+
+- Generate implementation plans that are fully executable by AI agents or humans
+- Use deterministic language with zero ambiguity
+- Structure all content for automated parsing and execution
+- Ensure complete self-containment with no external dependencies for understanding
+
+## Plan Structure Requirements
+
+Plans must consist of discrete, atomic phases containing executable tasks. Each phase must be independently processable by AI agents or humans without cross-phase dependencies unless explicitly declared.
+
+## Phase Architecture
+
+- Each phase must have measurable completion criteria
+- Tasks within phases must be executable in parallel unless dependencies are specified
+- All task descriptions must include specific file paths, function names, and exact implementation details
+- No task should require human interpretation or decision-making
+
+## AI-Optimized Implementation Standards
+
+- Use explicit, unambiguous language with zero interpretation required
+- Structure all content as machine-parseable formats (tables, lists, structured data)
+- Include specific file paths, line numbers, and exact code references where applicable
+- Define all variables, constants, and configuration values explicitly
+- Provide complete context within each task description
+- Use standardized prefixes for all identifiers (REQ-, TASK-, etc.)
+- Include validation criteria that can be automatically verified
+
+## Output File Specifications
+
+- Save implementation plan files in `/plan/` directory
+- Use naming convention: `[purpose]-[component]-[version].md`
+- Purpose prefixes: `upgrade|refactor|feature|data|infrastructure|process|architecture|design`
+- Example: `upgrade-system-command-4.md`, `feature-auth-module-1.md`
+- File must be valid Markdown with proper front matter structure
+
+## Mandatory Template Structure
+
+All implementation plans must strictly adhere to the following template. Each section is required and must be populated with specific, actionable content. AI agents must validate template compliance before execution.
+
+## Template Validation Rules
+
+- All front matter fields must be present and properly formatted
+- All section headers must match exactly (case-sensitive)
+- All identifier prefixes must follow the specified format
+- Tables must include all required columns
+- No placeholder text may remain in the final output
+
+## Status
+
+The status of the implementation plan must be clearly defined in the front matter and must reflect the current state of the plan. The status can be one of the following (status_color in brackets): `Completed` (bright green badge), `In progress` (yellow badge), `Planned` (blue badge), `Deprecated` (red badge), or `On Hold` (orange badge). It should also be displayed as a badge in the introduction section.
+
+```md
+---
+goal: [Concise Title Describing the Package Implementation Plan's Goal]
+version: [Optional: e.g., 1.0, Date]
+date_created: [YYYY-MM-DD]
+last_updated: [Optional: YYYY-MM-DD]
+owner: [Optional: Team/Individual responsible for this spec]
+status: 'Completed'|'In progress'|'Planned'|'Deprecated'|'On Hold'
+tags: [Optional: List of relevant tags or categories, e.g., `feature`, `upgrade`, `chore`, `architecture`, `migration`, `bug` etc]
+---
+
+# Introduction
+
+![Status: <status>](https://img.shields.io/badge/status-<status>-<status_color>)
+
+[A short concise introduction to the plan and the goal it is intended to achieve.]
+
+## 1. Requirements & Constraints
+
+[Explicitly list all requirements & constraints that affect the plan and constrain how it is implemented. Use bullet points or tables for clarity.]
+
+- **REQ-001**: Requirement 1
+- **SEC-001**: Security Requirement 1
+- **[3 LETTERS]-001**: Other Requirement 1
+- **CON-001**: Constraint 1
+- **GUD-001**: Guideline 1
+- **PAT-001**: Pattern to follow 1
+
+## 2. Implementation Steps
+
+### Implementation Phase 1
+
+- GOAL-001: [Describe the goal of this phase, e.g., "Implement feature X", "Refactor module Y", etc.]
+
+| Task | Description | Completed | Date |
+|------|-------------|-----------|------|
+| TASK-001 | Description of task 1 | ✅ | 2025-04-25 |
+| TASK-002 | Description of task 2 | |  |
+| TASK-003 | Description of task 3 | |  |
+
+### Implementation Phase 2
+
+- GOAL-002: [Describe the goal of this phase, e.g., "Implement feature X", "Refactor module Y", etc.]
+
+| Task | Description | Completed | Date |
+|------|-------------|-----------|------|
+| TASK-004 | Description of task 4 | |  |
+| TASK-005 | Description of task 5 | |  |
+| TASK-006 | Description of task 6 | |  |
+
+## 3. Alternatives
+
+[A bullet point list of any alternative approaches that were considered and why they were not chosen. This helps to provide context and rationale for the chosen approach.]
+
+- **ALT-001**: Alternative approach 1
+- **ALT-002**: Alternative approach 2
+
+## 4. Dependencies
+
+[List any dependencies that need to be addressed, such as libraries, frameworks, or other components that the plan relies on.]
+
+- **DEP-001**: Dependency 1
+- **DEP-002**: Dependency 2
+
+## 5. Files
+
+[List the files that will be affected by the feature or refactoring task.]
+
+- **FILE-001**: Description of file 1
+- **FILE-002**: Description of file 2
+
+## 6. Testing
+
+[List the tests that need to be implemented to verify the feature or refactoring task.]
+
+- **TEST-001**: Description of test 1
+- **TEST-002**: Description of test 2
+
+## 7. Risks & Assumptions
+
+[List any risks or assumptions related to the implementation of the plan.]
+
+- **RISK-001**: Risk 1
+- **ASSUMPTION-001**: Assumption 1
+
+## 8. Related Specifications / Further Reading
+
+[Link to related spec 1]
+[Link to relevant external documentation]
+```

--- a/.github/skills/dependabot/SKILL.md
+++ b/.github/skills/dependabot/SKILL.md
@@ -1,0 +1,422 @@
+---
+name: dependabot
+description: >-
+  Comprehensive guide for configuring and managing GitHub Dependabot. Use this skill when
+  users ask about creating or optimizing dependabot.yml files, managing Dependabot pull requests,
+  configuring dependency update strategies, setting up grouped updates, monorepo patterns,
+  multi-ecosystem groups, security update configuration, auto-triage rules, or any GitHub
+  Advanced Security (GHAS) supply chain security topic related to Dependabot.
+---
+
+# Dependabot Configuration & Management
+
+## Overview
+
+Dependabot is GitHub's built-in dependency management tool with three core capabilities:
+
+1. **Dependabot Alerts** — Notify when dependencies have known vulnerabilities (CVEs)
+2. **Dependabot Security Updates** — Auto-create PRs to fix vulnerable dependencies
+3. **Dependabot Version Updates** — Auto-create PRs to keep dependencies current
+
+All configuration lives in a **single file**: `.github/dependabot.yml` on the default branch. GitHub does **not** support multiple `dependabot.yml` files per repository.
+
+## Configuration Workflow
+
+Follow this process when creating or optimizing a `dependabot.yml`:
+
+### Step 1: Detect All Ecosystems
+
+Scan the repository for dependency manifests. Look for:
+
+| Ecosystem | YAML Value | Manifest Files |
+|---|---|---|
+| npm/pnpm/yarn | `npm` | `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock` |
+| pip/pipenv/poetry/uv | `pip` | `requirements.txt`, `Pipfile`, `pyproject.toml`, `setup.py` |
+| Docker | `docker` | `Dockerfile` |
+| Docker Compose | `docker-compose` | `docker-compose.yml` |
+| GitHub Actions | `github-actions` | `.github/workflows/*.yml` |
+| Go modules | `gomod` | `go.mod` |
+| Bundler (Ruby) | `bundler` | `Gemfile` |
+| Cargo (Rust) | `cargo` | `Cargo.toml` |
+| Composer (PHP) | `composer` | `composer.json` |
+| NuGet (.NET) | `nuget` | `*.csproj`, `packages.config` |
+| .NET SDK | `dotnet-sdk` | `global.json` |
+| Maven (Java) | `maven` | `pom.xml` |
+| Gradle (Java) | `gradle` | `build.gradle` |
+| Terraform | `terraform` | `*.tf` |
+| OpenTofu | `opentofu` | `*.tf` |
+| Helm | `helm` | `Chart.yaml` |
+| Hex (Elixir) | `mix` | `mix.exs` |
+| Swift | `swift` | `Package.swift` |
+| Pub (Dart) | `pub` | `pubspec.yaml` |
+| Bun | `bun` | `bun.lockb` |
+| Dev Containers | `devcontainers` | `devcontainer.json` |
+| Git Submodules | `gitsubmodule` | `.gitmodules` |
+| Pre-commit | `pre-commit` | `.pre-commit-config.yaml` |
+
+Note: pnpm and yarn both use the `npm` ecosystem value.
+
+### Step 2: Map Directory Locations
+
+For each ecosystem, identify where manifests live. Use `directories` (plural) with glob patterns for monorepos:
+
+```yaml
+directories:
+  - "/"           # root
+  - "/apps/*"     # all app subdirs
+  - "/packages/*" # all package subdirs
+  - "/lib-*"      # dirs starting with lib-
+  - "**/*"        # recursive (all subdirs)
+```
+
+Important: `directory` (singular) does NOT support globs. Use `directories` (plural) for wildcards.
+
+### Step 3: Configure Each Ecosystem Entry
+
+Every entry needs at minimum:
+
+```yaml
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+```
+
+### Step 4: Optimize with Grouping, Labels, and Scheduling
+
+See sections below for each optimization technique.
+
+## Monorepo Strategies
+
+### Glob Patterns for Workspace Coverage
+
+For monorepos with many packages, use glob patterns to avoid listing each directory:
+
+```yaml
+- package-ecosystem: "npm"
+  directories:
+    - "/"
+    - "/apps/*"
+    - "/packages/*"
+    - "/services/*"
+  schedule:
+    interval: "weekly"
+```
+
+### Cross-Directory Grouping
+
+Use `group-by: dependency-name` to create a single PR when the same dependency updates across multiple directories:
+
+```yaml
+groups:
+  monorepo-deps:
+    group-by: dependency-name
+```
+
+This creates one PR per dependency across all specified directories, reducing CI costs and review burden.
+
+Limitations:
+- All directories must use the same package ecosystem
+- Applies to version updates only
+- Incompatible version constraints create separate PRs
+
+### Standalone Packages Outside Workspaces
+
+If a directory has its own lockfile and is NOT part of the workspace (e.g., scripts in `.github/`), create a separate ecosystem entry for it.
+
+## Dependency Grouping
+
+Reduce PR noise by grouping related dependencies into single PRs.
+
+### By Dependency Type
+
+```yaml
+groups:
+  dev-dependencies:
+    dependency-type: "development"
+    update-types: ["minor", "patch"]
+  production-dependencies:
+    dependency-type: "production"
+    update-types: ["minor", "patch"]
+```
+
+### By Name Pattern
+
+```yaml
+groups:
+  angular:
+    patterns: ["@angular*"]
+    update-types: ["minor", "patch"]
+  testing:
+    patterns: ["jest*", "@testing-library*", "ts-jest"]
+```
+
+### For Security Updates
+
+```yaml
+groups:
+  security-patches:
+    applies-to: security-updates
+    patterns: ["*"]
+    update-types: ["patch", "minor"]
+```
+
+Key behaviors:
+- Dependencies matching multiple groups go to the **first** match
+- `applies-to` defaults to `version-updates` when absent
+- Ungrouped dependencies get individual PRs
+
+## Multi-Ecosystem Groups
+
+Combine updates across different package ecosystems into a single PR:
+
+```yaml
+version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+    labels: ["infrastructure", "dependencies"]
+
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    patterns: ["nginx", "redis"]
+    multi-ecosystem-group: "infrastructure"
+
+  - package-ecosystem: "terraform"
+    directory: "/"
+    patterns: ["aws*"]
+    multi-ecosystem-group: "infrastructure"
+```
+
+The `patterns` key is required when using `multi-ecosystem-group`.
+
+## PR Customization
+
+### Labels
+
+```yaml
+labels:
+  - "dependencies"
+  - "npm"
+```
+
+Set `labels: []` to disable all labels including defaults. SemVer labels (`major`, `minor`, `patch`) are always applied if present in the repo.
+
+### Commit Messages
+
+```yaml
+commit-message:
+  prefix: "deps"
+  prefix-development: "deps-dev"
+  include: "scope"  # adds deps/deps-dev scope after prefix
+```
+
+### Assignees and Milestones
+
+```yaml
+assignees: ["security-team-lead"]
+milestone: 4  # numeric ID from milestone URL
+```
+
+### Branch Name Separator
+
+```yaml
+pull-request-branch-name:
+  separator: "-"  # default is /
+```
+
+### Target Branch
+
+```yaml
+target-branch: "develop"  # PRs target this instead of default branch
+```
+
+Note: When `target-branch` is set, security updates still target the default branch; all ecosystem config only applies to version updates.
+
+## Schedule Optimization
+
+### Intervals
+
+Supported: `daily`, `weekly`, `monthly`, `quarterly`, `semiannually`, `yearly`, `cron`
+
+```yaml
+schedule:
+  interval: "weekly"
+  day: "monday"         # for weekly only
+  time: "09:00"         # HH:MM format
+  timezone: "America/New_York"
+```
+
+### Cron Expressions
+
+```yaml
+schedule:
+  interval: "cron"
+  cronjob: "0 9 * * 1"  # Every Monday at 9 AM
+```
+
+### Cooldown Periods
+
+Delay updates for newly released versions to avoid early-adopter issues:
+
+```yaml
+cooldown:
+  default-days: 5
+  semver-major-days: 30
+  semver-minor-days: 7
+  semver-patch-days: 3
+  include: ["*"]
+  exclude: ["critical-lib"]
+```
+
+Cooldown applies to version updates only, not security updates.
+
+## Security Updates Configuration
+
+### Enable via Repository Settings
+
+Settings → Advanced Security → Enable Dependabot alerts, security updates, and grouped security updates.
+
+### Group Security Updates in YAML
+
+```yaml
+groups:
+  security-patches:
+    applies-to: security-updates
+    patterns: ["*"]
+    update-types: ["patch", "minor"]
+```
+
+### Disable Version Updates (Security Only)
+
+```yaml
+open-pull-requests-limit: 0  # disables version update PRs
+```
+
+### Auto-Triage Rules
+
+GitHub presets auto-dismiss low-impact alerts for development dependencies. Custom rules can filter by severity, package name, CWE, and more. Configure in repository Settings → Advanced Security.
+
+## PR Comment Commands
+
+Interact with Dependabot PRs using `@dependabot` comments.
+
+> **Note:** As of January 2026, merge/close/reopen commands have been deprecated.
+> Use GitHub's native UI, CLI (`gh pr merge`), or auto-merge instead.
+
+| Command | Effect |
+|---|---|
+| `@dependabot rebase` | Rebase the PR |
+| `@dependabot recreate` | Recreate the PR from scratch |
+| `@dependabot ignore this dependency` | Close and never update this dependency |
+| `@dependabot ignore this major version` | Ignore this major version |
+| `@dependabot ignore this minor version` | Ignore this minor version |
+| `@dependabot ignore this patch version` | Ignore this patch version |
+
+For grouped PRs, additional commands:
+- `@dependabot ignore DEPENDENCY_NAME` — ignore specific dependency in group
+- `@dependabot unignore DEPENDENCY_NAME` — clear ignores, reopen with updates
+- `@dependabot unignore *` — clear all ignores for all dependencies in group
+- `@dependabot show DEPENDENCY_NAME ignore conditions` — display current ignores
+
+For the complete command reference, see `references/pr-commands.md`.
+
+## Ignore and Allow Rules
+
+### Ignore Specific Dependencies
+
+```yaml
+ignore:
+  - dependency-name: "lodash"
+  - dependency-name: "@types/node"
+    update-types: ["version-update:semver-patch"]
+  - dependency-name: "express"
+    versions: ["5.x"]
+```
+
+### Allow Only Specific Types
+
+```yaml
+allow:
+  - dependency-type: "production"
+  - dependency-name: "express"
+```
+
+Rule: If a dependency matches both `allow` and `ignore`, it is **ignored**.
+
+### Exclude Paths
+
+```yaml
+exclude-paths:
+  - "vendor/**"
+  - "test/fixtures/**"
+```
+
+## Advanced Options
+
+### Versioning Strategy
+
+Controls how Dependabot edits version constraints:
+
+| Value | Behavior |
+|---|---|
+| `auto` | Default — increase for apps, widen for libraries |
+| `increase` | Always increase minimum version |
+| `increase-if-necessary` | Only change if current range excludes new version |
+| `lockfile-only` | Only update lockfiles, ignore manifests |
+| `widen` | Widen range to include both old and new versions |
+
+### Rebase Strategy
+
+```yaml
+rebase-strategy: "disabled"  # stop auto-rebasing
+```
+
+Allow rebase over extra commits by including `[dependabot skip]` in commit messages.
+
+### Open PR Limit
+
+```yaml
+open-pull-requests-limit: 10  # default is 5 for version, 10 for security
+```
+
+Set to `0` to disable version updates entirely.
+
+### Private Registries
+
+```yaml
+registries:
+  npm-private:
+    type: npm-registry
+    url: https://npm.example.com
+    token: ${{secrets.NPM_TOKEN}}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - npm-private
+```
+
+## FAQ
+
+**Can I have multiple `dependabot.yml` files?**
+No. GitHub supports exactly one file at `.github/dependabot.yml`. Use multiple `updates` entries within that file for different ecosystems and directories.
+
+**Does Dependabot support pnpm?**
+Yes. Use `package-ecosystem: "npm"` — Dependabot detects `pnpm-lock.yaml` automatically.
+
+**How do I reduce PR noise in a monorepo?**
+Use `groups` to batch updates, `directories` with globs for coverage, and `group-by: dependency-name` for cross-directory grouping. Consider `monthly` or `quarterly` intervals for low-priority ecosystems.
+
+**How do I handle dependencies outside the workspace?**
+Create a separate ecosystem entry with its own `directory` pointing to that location.
+
+## Resources
+
+- `references/dependabot-yml-reference.md` — Complete YAML options reference
+- `references/pr-commands.md` — Full PR comment commands reference
+- `references/example-configs.md` — Real-world configuration examples

--- a/.github/skills/dependabot/references/dependabot-yml-reference.md
+++ b/.github/skills/dependabot/references/dependabot-yml-reference.md
@@ -1,0 +1,374 @@
+# Dependabot YAML Options Reference
+
+Complete reference for all configuration options in `.github/dependabot.yml`.
+
+## File Structure
+
+```yaml
+version: 2                    # Required, always 2
+
+registries:                   # Optional: private registry access
+  REGISTRY_NAME:
+    type: "..."
+    url: "..."
+
+multi-ecosystem-groups:       # Optional: cross-ecosystem grouping
+  GROUP_NAME:
+    schedule:
+      interval: "..."
+
+updates:                      # Required: list of ecosystem configurations
+  - package-ecosystem: "..."  # Required
+    directory: "/"            # Required (or directories)
+    schedule:                 # Required
+      interval: "..."
+```
+
+## Required Keys
+
+### `version`
+
+Always `2`. Must be at the top level.
+
+### `package-ecosystem`
+
+Defines which package manager to monitor. One entry per ecosystem (can have multiple entries for the same ecosystem with different directories).
+
+| Package Manager | YAML Value | Manifest Files |
+|---|---|---|
+| Bazel | `bazel` | `MODULE.bazel`, `WORKSPACE` |
+| Bun | `bun` | `bun.lockb` |
+| Bundler (Ruby) | `bundler` | `Gemfile`, `Gemfile.lock` |
+| Cargo (Rust) | `cargo` | `Cargo.toml`, `Cargo.lock` |
+| Composer (PHP) | `composer` | `composer.json`, `composer.lock` |
+| Conda | `conda` | `environment.yml` |
+| Dev Containers | `devcontainers` | `devcontainer.json` |
+| Docker | `docker` | `Dockerfile` |
+| Docker Compose | `docker-compose` | `docker-compose.yml` |
+| .NET SDK | `dotnet-sdk` | `global.json` |
+| Elm | `elm` | `elm.json` |
+| Git Submodules | `gitsubmodule` | `.gitmodules` |
+| GitHub Actions | `github-actions` | `.github/workflows/*.yml` |
+| Go Modules | `gomod` | `go.mod`, `go.sum` |
+| Gradle | `gradle` | `build.gradle`, `build.gradle.kts` |
+| Helm | `helm` | `Chart.yaml` |
+| Hex (Elixir) | `mix` | `mix.exs`, `mix.lock` |
+| Julia | `julia` | `Project.toml`, `Manifest.toml` |
+| Maven | `maven` | `pom.xml` |
+| npm/pnpm/yarn | `npm` | `package.json`, lockfiles |
+| NuGet | `nuget` | `*.csproj`, `packages.config` |
+| OpenTofu | `opentofu` | `*.tf` |
+| pip/pipenv/poetry/uv | `pip` | `requirements.txt`, `Pipfile`, `pyproject.toml` |
+| Pre-commit | `pre-commit` | `.pre-commit-config.yaml` |
+| Pub (Dart/Flutter) | `pub` | `pubspec.yaml` |
+| Rust Toolchain | `rust-toolchain` | `rust-toolchain.toml` |
+| Swift | `swift` | `Package.swift` |
+| Terraform | `terraform` | `*.tf` |
+| uv | `uv` | `uv.lock`, `pyproject.toml` |
+| vcpkg | `vcpkg` | `vcpkg.json` |
+
+### `directory` / `directories`
+
+Location of package manifests relative to repo root.
+
+- `directory` — single path (no glob support)
+- `directories` — list of paths (supports `*` and `**` globs)
+
+```yaml
+# Single directory
+directory: "/"
+
+# Multiple directories with globs
+directories:
+  - "/"
+  - "/apps/*"
+  - "/packages/*"
+```
+
+For GitHub Actions, use `/` — Dependabot automatically searches `.github/workflows/`.
+
+### `schedule`
+
+How often to check for updates.
+
+| Parameter | Values | Notes |
+|---|---|---|
+| `interval` | `daily`, `weekly`, `monthly`, `quarterly`, `semiannually`, `yearly`, `cron` | Required |
+| `day` | `monday`–`sunday` | Weekly only |
+| `time` | `HH:MM` | UTC by default |
+| `timezone` | IANA timezone string | e.g., `America/New_York` |
+| `cronjob` | Cron expression | Required when interval is `cron` |
+
+```yaml
+schedule:
+  interval: "weekly"
+  day: "tuesday"
+  time: "09:00"
+  timezone: "Europe/London"
+```
+
+## Grouping Options
+
+### `groups`
+
+Group dependencies into fewer PRs.
+
+| Parameter | Purpose | Values |
+|---|---|---|
+| `IDENTIFIER` | Group name (used in branch/PR title) | Letters, pipes, underscores, hyphens |
+| `applies-to` | Update type | `version-updates` (default), `security-updates` |
+| `dependency-type` | Filter by type | `development`, `production` |
+| `patterns` | Include matching names | List of strings with `*` wildcard |
+| `exclude-patterns` | Exclude matching names | List of strings with `*` wildcard |
+| `update-types` | SemVer filter | `major`, `minor`, `patch` |
+| `group-by` | Cross-directory grouping | `dependency-name` |
+
+```yaml
+groups:
+  dev-deps:
+    dependency-type: "development"
+    update-types: ["minor", "patch"]
+  angular:
+    patterns: ["@angular*"]
+    exclude-patterns: ["@angular/cdk"]
+  monorepo:
+    group-by: dependency-name
+```
+
+### `multi-ecosystem-groups` (top-level)
+
+Group updates across different ecosystems into one PR.
+
+```yaml
+multi-ecosystem-groups:
+  GROUP_NAME:
+    schedule:
+      interval: "weekly"
+    labels: ["infrastructure"]
+    assignees: ["@platform-team"]
+```
+
+Assign ecosystems with `multi-ecosystem-group: "GROUP_NAME"` in each `updates` entry. The `patterns` key is required in each ecosystem entry when using this feature.
+
+## Filtering Options
+
+### `allow`
+
+Explicitly define which dependencies to maintain.
+
+| Parameter | Purpose |
+|---|---|
+| `dependency-name` | Match by name (supports `*` wildcard) |
+| `dependency-type` | `direct`, `indirect`, `all`, `production`, `development` |
+
+```yaml
+allow:
+  - dependency-type: "production"
+  - dependency-name: "express"
+```
+
+### `ignore`
+
+Exclude dependencies or versions from updates.
+
+| Parameter | Purpose |
+|---|---|
+| `dependency-name` | Match by name (supports `*` wildcard) |
+| `versions` | Specific versions or ranges (e.g., `["5.x"]`, `[">=2.0.0"]`) |
+| `update-types` | SemVer levels: `version-update:semver-major`, `version-update:semver-minor`, `version-update:semver-patch` |
+
+```yaml
+ignore:
+  - dependency-name: "lodash"
+  - dependency-name: "@types/node"
+    update-types: ["version-update:semver-patch"]
+  - dependency-name: "express"
+    versions: ["5.x"]
+```
+
+Rule: if a dependency matches both `allow` and `ignore`, it is **ignored**.
+
+### `exclude-paths`
+
+Ignore specific directories or files during manifest scanning.
+
+```yaml
+exclude-paths:
+  - "vendor/**"
+  - "test/fixtures/**"
+  - "*.lock"
+```
+
+Supports glob patterns: `*` (single segment), `**` (recursive), specific file paths.
+
+## PR Customization Options
+
+### `labels`
+
+```yaml
+labels:
+  - "dependencies"
+  - "npm"
+```
+
+Set `labels: []` to disable all labels. SemVer labels are always applied if they exist in the repo.
+
+### `assignees`
+
+```yaml
+assignees:
+  - "user1"
+  - "user2"
+```
+
+Assignees must have write access (or read access for org repos).
+
+### `milestone`
+
+```yaml
+milestone: 4  # numeric ID from milestone URL
+```
+
+### `commit-message`
+
+```yaml
+commit-message:
+  prefix: "deps"              # up to 50 chars; colon auto-added if ends with letter/number
+  prefix-development: "deps-dev"  # separate prefix for dev dependencies
+  include: "scope"            # adds deps/deps-dev after prefix
+```
+
+### `pull-request-branch-name`
+
+```yaml
+pull-request-branch-name:
+  separator: "-"  # options: "-", "_", "/"
+```
+
+### `target-branch`
+
+```yaml
+target-branch: "develop"
+```
+
+When set, version update config only applies to version updates. Security updates always target the default branch.
+
+## Scheduling & Rate Limiting
+
+### `cooldown`
+
+Delay version updates for newly released versions:
+
+| Parameter | Purpose |
+|---|---|
+| `default-days` | Default cooldown (1–90 days) |
+| `semver-major-days` | Cooldown for major updates |
+| `semver-minor-days` | Cooldown for minor updates |
+| `semver-patch-days` | Cooldown for patch updates |
+| `include` | Dependencies to apply cooldown (up to 150, supports `*`) |
+| `exclude` | Dependencies exempt from cooldown (up to 150, takes precedence) |
+
+```yaml
+cooldown:
+  default-days: 5
+  semver-major-days: 30
+  semver-minor-days: 7
+  semver-patch-days: 3
+  include: ["*"]
+  exclude: ["critical-security-lib"]
+```
+
+### `open-pull-requests-limit`
+
+```yaml
+open-pull-requests-limit: 10  # default: 5 for version updates
+```
+
+Set to `0` to disable version updates entirely. Security updates have a separate internal limit of 10.
+
+## Advanced Options
+
+### `versioning-strategy`
+
+Supported by: `bundler`, `cargo`, `composer`, `mix`, `npm`, `pip`, `pub`, `uv`.
+
+| Value | Behavior |
+|---|---|
+| `auto` | Default: increase for apps, widen for libraries |
+| `increase` | Always increase minimum version |
+| `increase-if-necessary` | Only change if current range excludes new version |
+| `lockfile-only` | Only update lockfiles |
+| `widen` | Widen range to include old and new versions |
+
+### `rebase-strategy`
+
+```yaml
+rebase-strategy: "disabled"
+```
+
+Default behavior: Dependabot auto-rebases PRs on conflicts. Rebasing stops 30 days after PR opens.
+
+Allow Dependabot to force push over extra commits by including `[dependabot skip]` in commit messages.
+
+### `vendor`
+
+Supported by: `bundler`, `gomod`.
+
+```yaml
+vendor: true  # maintain vendored dependencies
+```
+
+Go modules auto-detect vendored dependencies.
+
+### `insecure-external-code-execution`
+
+Supported by: `bundler`, `mix`, `pip`.
+
+```yaml
+insecure-external-code-execution: "allow"
+```
+
+Allows Dependabot to execute code in manifests during updates. Required for some ecosystems that run code during resolution.
+
+## Private Registries
+
+### Top-Level Registry Definition
+
+```yaml
+registries:
+  npm-private:
+    type: npm-registry
+    url: https://npm.example.com
+    token: ${{secrets.NPM_TOKEN}}
+
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2
+    username: ""
+    password: ""
+
+  docker-ghcr:
+    type: docker-registry
+    url: https://ghcr.io
+    username: ${{secrets.GHCR_USER}}
+    password: ${{secrets.GHCR_TOKEN}}
+
+  python-private:
+    type: python-index
+    url: https://pypi.example.com/simple
+    token: ${{secrets.PYPI_TOKEN}}
+```
+
+### Associating Registries with Ecosystems
+
+```yaml
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - npm-private
+    schedule:
+      interval: "weekly"
+```
+
+Use `registries: "*"` to allow access to all defined registries.

--- a/.github/skills/dependabot/references/example-configs.md
+++ b/.github/skills/dependabot/references/example-configs.md
@@ -1,0 +1,409 @@
+# Dependabot Configuration Examples
+
+Real-world `dependabot.yml` configurations for common scenarios.
+
+---
+
+## 1. Basic Single Ecosystem
+
+Minimal configuration for a single npm project:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+---
+
+## 2. Monorepo with Glob Patterns
+
+Turborepo/pnpm monorepo with multiple workspace packages:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/apps/*"
+      - "/packages/*"
+      - "/services/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+```
+
+---
+
+## 3. Grouped Dev vs Production Dependencies
+
+Separate dev and production updates to prioritize review of production changes:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-deps:
+        dependency-type: "production"
+      dev-deps:
+        dependency-type: "development"
+        exclude-patterns:
+          - "eslint*"
+      linting:
+        patterns:
+          - "eslint*"
+          - "prettier*"
+          - "@typescript-eslint*"
+```
+
+---
+
+## 4. Cross-Directory Grouping (Monorepo)
+
+Create one PR per shared dependency across directories:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/frontend"
+      - "/admin-panel"
+      - "/mobile-app"
+    schedule:
+      interval: "weekly"
+    groups:
+      monorepo-dependencies:
+        group-by: dependency-name
+```
+
+When `lodash` updates in all three directories, Dependabot creates a single PR.
+
+---
+
+## 5. Multi-Ecosystem Group (Docker + Terraform)
+
+Consolidate infrastructure dependency updates into a single PR:
+
+```yaml
+version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+    labels: ["infrastructure", "dependencies"]
+    assignees: ["@platform-team"]
+
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    patterns: ["nginx", "redis", "postgres"]
+    multi-ecosystem-group: "infrastructure"
+
+  - package-ecosystem: "terraform"
+    directory: "/"
+    patterns: ["aws*", "terraform-*"]
+    multi-ecosystem-group: "infrastructure"
+```
+
+---
+
+## 6. Security Updates Only (Version Updates Disabled)
+
+Monitor for security vulnerabilities without version update PRs:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0  # disables version update PRs
+    groups:
+      security-all:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types: ["patch", "minor"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+```
+
+---
+
+## 7. Private Registries
+
+Access private npm and Docker registries:
+
+```yaml
+version: 2
+
+registries:
+  npm-private:
+    type: npm-registry
+    url: https://npm.internal.example.com
+    token: ${{secrets.NPM_PRIVATE_TOKEN}}
+
+  docker-ghcr:
+    type: docker-registry
+    url: https://ghcr.io
+    username: ${{secrets.GHCR_USER}}
+    password: ${{secrets.GHCR_TOKEN}}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - npm-private
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    registries:
+      - docker-ghcr
+    schedule:
+      interval: "weekly"
+```
+
+---
+
+## 8. Cooldown Periods
+
+Delay updates for newly released versions to avoid early-adopter bugs:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 3
+      include: ["*"]
+      exclude:
+        - "security-critical-lib"
+        - "@company/internal-*"
+```
+
+---
+
+## 9. Cron Scheduling
+
+Run updates at a specific time using cron expressions:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 * * 1"  # Every Monday at 9:00 AM
+      timezone: "America/New_York"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 6 1 * *"  # First day of each month at 6:00 AM
+```
+
+---
+
+## 10. Full-Featured Configuration
+
+A comprehensive example combining multiple optimizations:
+
+```yaml
+version: 2
+
+registries:
+  npm-private:
+    type: npm-registry
+    url: https://npm.example.com
+    token: ${{secrets.NPM_TOKEN}}
+
+updates:
+  # npm — monorepo workspaces
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/apps/*"
+      - "/packages/*"
+      - "/services/*"
+    registries:
+      - npm-private
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      angular:
+        patterns: ["@angular*"]
+        update-types: ["minor", "patch"]
+      security-patches:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types: ["patch", "minor"]
+    ignore:
+      - dependency-name: "aws-sdk"
+        update-types: ["version-update:semver-major"]
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    assignees:
+      - "security-lead"
+    open-pull-requests-limit: 15
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directories:
+      - "/services/*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"
+
+  # pip
+  - package-ecosystem: "pip"
+    directory: "/scripts"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "python"
+    versioning-strategy: "increase-if-necessary"
+    commit-message:
+      prefix: "deps"
+
+  # Terraform
+  - package-ecosystem: "terraform"
+    directory: "/infra"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "terraform"
+    commit-message:
+      prefix: "infra"
+```
+
+---
+
+## 11. Ignore Patterns and Versioning Strategy
+
+Control exactly what gets updated and how:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: "increase"
+    ignore:
+      # Never auto-update to Express 5.x (breaking changes)
+      - dependency-name: "express"
+        versions: ["5.x"]
+      # Skip patch updates for type definitions
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-patch"]
+      # Ignore all updates for a vendored package
+      - dependency-name: "legacy-internal-lib"
+    allow:
+      - dependency-type: "all"
+    exclude-paths:
+      - "vendor/**"
+      - "test/fixtures/**"
+```
+
+---
+
+## 12. Target Non-Default Branch
+
+Test updates on a development branch before production:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "staging"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+```
+
+Note: Security updates always target the default branch regardless of `target-branch`.

--- a/.github/skills/dependabot/references/pr-commands.md
+++ b/.github/skills/dependabot/references/pr-commands.md
@@ -1,0 +1,91 @@
+# Dependabot PR Comment Commands
+
+Interact with Dependabot pull requests by commenting `@dependabot <command>`. Dependabot acknowledges commands with a thumbs-up reaction.
+
+> **Deprecation Notice (January 27, 2026):** The following commands have been removed:
+> `@dependabot merge`, `@dependabot squash and merge`, `@dependabot cancel merge`,
+> `@dependabot close`, and `@dependabot reopen`.
+> Use GitHub's native UI, CLI (`gh pr merge`), API, or auto-merge feature instead.
+
+## Commands for Individual PRs
+
+| Command | Description |
+|---|---|
+| `@dependabot rebase` | Rebase the PR against the target branch |
+| `@dependabot recreate` | Recreate the PR from scratch, overwriting any manual edits |
+| `@dependabot ignore this dependency` | Close the PR and stop all future updates for this dependency |
+| `@dependabot ignore this major version` | Close and stop updates for this major version |
+| `@dependabot ignore this minor version` | Close and stop updates for this minor version |
+| `@dependabot ignore this patch version` | Close and stop updates for this patch version |
+| `@dependabot show DEPENDENCY_NAME ignore conditions` | Display a table of all current ignore conditions for the dependency |
+
+## Commands for Grouped Updates
+
+These commands work on Dependabot PRs created by grouped version or security updates.
+
+| Command | Description |
+|---|---|
+| `@dependabot ignore DEPENDENCY_NAME` | Close the PR and stop updating this dependency in the group |
+| `@dependabot ignore DEPENDENCY_NAME major version` | Stop updating this dependency's major version |
+| `@dependabot ignore DEPENDENCY_NAME minor version` | Stop updating this dependency's minor version |
+| `@dependabot ignore DEPENDENCY_NAME patch version` | Stop updating this dependency's patch version |
+| `@dependabot unignore *` | Close current PR, clear ALL ignore conditions for ALL dependencies in the group, open a new PR |
+| `@dependabot unignore DEPENDENCY_NAME` | Close current PR, clear all ignores for a specific dependency, open a new PR with its updates |
+| `@dependabot unignore DEPENDENCY_NAME IGNORE_CONDITION` | Close current PR, clear a specific ignore condition, open a new PR |
+
+## Usage Examples
+
+### Merge After CI (Use Native GitHub Features)
+
+Auto-merge is the recommended replacement for the deprecated `@dependabot merge` command:
+
+```bash
+# Enable auto-merge via GitHub CLI
+gh pr merge <PR_NUMBER> --auto --squash
+
+# Or enable auto-merge via the GitHub UI:
+# PR → "Enable auto-merge" → select merge method → confirm
+```
+
+GitHub will automatically merge the PR once all required CI checks pass.
+
+### Ignore a Major Version Bump
+
+```
+@dependabot ignore this major version
+```
+
+Useful when a major version has breaking changes and migration is not yet planned.
+
+### Check Active Ignore Conditions
+
+```
+@dependabot show express ignore conditions
+```
+
+Displays a table showing all ignore conditions currently stored for the `express` dependency.
+
+### Unignore a Dependency in a Group
+
+```
+@dependabot unignore lodash
+```
+
+Closes the current grouped PR, clears all ignore conditions for `lodash`, and opens a new PR that includes available `lodash` updates.
+
+### Unignore a Specific Condition
+
+```
+@dependabot unignore express [< 1.9, > 1.8.0]
+```
+
+Clears only the specified version range ignore for `express`.
+
+## Tips
+
+- **Rebase vs Recreate**: Use `rebase` to resolve conflicts while keeping your review state. Use `recreate` to start fresh if the PR has diverged significantly.
+- **Force push over extra commits**: If you've pushed commits to a Dependabot branch and want Dependabot to rebase over them, include `[dependabot skip]` in your commit message.
+- **Persistent ignores**: Ignore commands via PR comments are stored centrally. For transparency in team repos, prefer using `ignore` in `dependabot.yml` instead.
+- **Merging Dependabot PRs**: Use GitHub's native auto-merge feature, the CLI (`gh pr merge`), or the web UI. The old `@dependabot merge` commands were deprecated in January 2026.
+- **Closing/Reopening**: Use the GitHub UI or CLI. The old `@dependabot close` and `@dependabot reopen` commands were deprecated in January 2026.
+- **Grouped commands**: When using `@dependabot unignore`, Dependabot closes the current PR and opens a fresh one with the updated dependency set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,282 @@
+# AGENTS.md
+
+## Project Overview
+
+Backup Orchestrator is a monorepo for a restic-based backup platform:
+
+- Server: Go service exposing REST (Chi), gRPC, SQLite, and embedded frontend assets.
+- Agent: Go daemon running on backup hosts, executes restic/rclone, schedules jobs, and streams status over gRPC.
+- Frontend: Vue 3 + TypeScript + Vite + Pinia SPA.
+- Proto: Shared protobuf contracts generated into both Go modules.
+
+Primary design constraints:
+
+- Agents connect outbound to server (server is the only inbound endpoint).
+- Agent must keep operating on last-known config when server is unavailable.
+- No ORM; use raw SQL through `database/sql`.
+- SQLite driver is `modernc.org/sqlite` (pure Go, no CGO).
+
+## Monorepo Layout
+
+- `server/`: Go module for API, gRPC server, config push, DB.
+- `agent/`: Go module for scheduler, restic executor, reporting.
+- `frontend/`: Vue app.
+- `proto/`: `.proto` schemas and buf config.
+- `docs/`: architecture, API, schema, workflow docs.
+- `docker/`: Dockerfiles and compose setup.
+
+When editing code, scope changes to one module unless cross-module updates are required.
+
+## Required Tooling
+
+- Go 1.26.x (see `server/go.mod`, `agent/go.mod`).
+- Node.js 22+.
+- npm.
+- just (task runner).
+- buf (for proto generation/lint).
+- golangci-lint (for lint recipes).
+- lefthook (pre-commit hooks).
+
+Recommended local workflow is Nix + direnv:
+
+```bash
+direnv allow
+nix develop
+```
+
+## Setup Commands
+
+From repository root:
+
+```bash
+# frontend deps
+cd frontend && npm ci
+
+# install git hooks
+cd .. && lefthook install
+
+# inspect available tasks
+just --list
+```
+
+Local defaults are in `.env.dev`. Override with `.env.dev.local`.
+
+## Development Workflow
+
+Use root `just` recipes whenever possible:
+
+```bash
+# run each service independently
+just dev-server
+just dev-agent
+just dev-frontend
+
+# or run all in zellij tabs
+just dev
+
+# stop dev processes if needed
+just dev-stop
+```
+
+Notes:
+
+- `just dev-server` sets `BACKUP_DB_PATH` to `tmp/server.db`.
+- `just dev-agent` sets `BACKUP_DATA_DIR` to `tmp/agent-data`.
+- Frontend dev server proxies `/api` to server on localhost:8080.
+
+## Build Instructions
+
+```bash
+# full build (frontend + server + agent)
+just build
+
+# targeted builds
+just build-frontend
+just build-server
+just build-server-only
+just build-agent
+```
+
+Build outputs:
+
+- Binaries: `bin/server`, `bin/agent`.
+- Frontend dist: `frontend/dist` and copied to `server/internal/frontend/dist`.
+
+Version metadata (`Version`, `Commit`, `BuildDate`) is injected via ldflags in `justfile`.
+
+## Testing Instructions
+
+Run from repo root:
+
+```bash
+# all tests
+just test
+
+# per module
+just test-server
+just test-agent
+just test-frontend
+
+# coverage helpers (Go modules)
+just test-cover
+just test-cover-server
+just test-cover-agent
+```
+
+Direct module-level commands:
+
+```bash
+cd server && go test -race ./...
+cd agent && go test -race ./...
+cd frontend && npm test
+```
+
+Focused testing examples:
+
+```bash
+# run one Go test function
+cd server && go test ./... -run TestName
+
+# run one frontend test by name
+cd frontend && npx vitest run -t "test name"
+```
+
+Test conventions:
+
+- Go tests are colocated as `*_test.go`.
+- Frontend uses Vitest (`frontend/src/**` and `frontend/src/test/**`).
+- Add or update tests for behavior changes.
+
+## Code Style and Conventions
+
+### Go
+
+- Format with `gofmt` (use `just fmt`).
+- Vet with `go vet` (use `just vet`).
+- Lint with `golangci-lint` (use `just lint`).
+- Keep packages under `internal/` unless explicitly public.
+- Return wrapped errors (`fmt.Errorf("context: %w", err)`), do not panic in normal flow.
+- Use `github.com/google/uuid` for entity IDs.
+- Keep SQL explicit; avoid introducing ORMs.
+
+### Frontend
+
+- Use Vue 3 SFCs with `<script setup lang="ts">`.
+- Keep API calls in `frontend/src/api/client.ts` (no direct fetch in components).
+- Keep shared API types in `frontend/src/types/api.ts`.
+- Use Pinia stores in `frontend/src/stores/`.
+- Styling is Tailwind-based.
+
+### Proto
+
+- Regenerate and lint on schema changes:
+
+```bash
+just proto-gen
+just proto-lint
+just proto-breaking
+```
+
+## CI and Required Checks
+
+Relevant workflows are in `.github/workflows/`:
+
+- `ci.yml`: tests, fmt/vet, lint (PR), proto checks (PR), build.
+- `pr-label-check.yml`: enforces PR labels.
+- `release-drafter.yml`: maintains rolling draft release.
+- `build-push.yml`: builds and pushes images on main and tags.
+
+Before opening a PR, at minimum run:
+
+```bash
+just test
+just fmt
+just vet
+just lint
+```
+
+If proto changed, also run:
+
+```bash
+just proto-gen
+just proto-lint
+just proto-breaking
+```
+
+## Pull Request Rules
+
+Follow `CONTRIBUTING.md` and `.github/pull_request_template.md`.
+
+Required label policy (enforced by CI):
+
+- Exactly one `type/*` label.
+- At least one `area/*` label.
+- Optional `impact/*` labels when relevant.
+
+Release notes:
+
+- Fill the `release-note` fenced block in the PR template.
+- Use `NONE` for non-user-facing work.
+
+PR title guidance:
+
+- Use short, imperative, specific titles.
+- Keep around 72 chars or less when possible.
+- Squash merge is used; PR title becomes merge commit subject.
+
+## Security and Operations Notes
+
+- Do not commit secrets.
+- Ensure `BACKUP_ENCRYPTION_KEY` handling remains compatible with current server behavior.
+- Be careful with command execution paths and hook/script inputs.
+- Avoid logging sensitive repository credentials.
+- For production changes, consider impact on:
+  - agent offline operation,
+  - reconnect/report replay,
+  - backward compatibility of proto and DB behavior.
+
+## Docker and Release Operations
+
+```bash
+just docker-build
+just docker-push
+```
+
+Release note generation:
+
+```bash
+just release-notes
+just release-notes-polished
+```
+
+The workflow `refresh-release-draft.yml` can refresh the draft release body from PR `release-note` blocks.
+
+## Debugging and Troubleshooting
+
+- Check the task graph first: `just --list`.
+- If generated code is stale, run `just proto-gen`.
+- If server build fails due to missing embedded assets, run `just build-frontend` (or create `server/internal/frontend/dist` stub as CI does).
+- If hooks fail locally, reinstall: `lefthook install`.
+- Keep fixes minimal and localized; avoid opportunistic refactors in bugfix PRs.
+
+## Agent Working Agreement for This Repo
+
+When acting as an automated coding agent in this repository:
+
+1. Prefer root `just` recipes over ad-hoc commands.
+2. Keep changes focused; avoid touching unrelated modules.
+3. Update tests and docs with behavior changes.
+4. Preserve established architecture decisions listed in docs.
+5. Run relevant tests/linters before finalizing.
+6. Include migration notes when introducing breaking behavior.
+
+## Reference Docs
+
+- `README.md`
+- `CLAUDE.md`
+- `CONTRIBUTING.md`
+- `docs/workflow.md`
+- `docs/architecture-overview.md`
+- `docs/grpc-api.md`
+- `docs/database-schema.md`
+- `docs/maintainer-guidelines.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,24 @@ lefthook install   # register hooks after first clone
 
 Hooks run `gofmt` (format check) and `go vet` on staged Go files. They are intentionally lightweight — heavy checks live in CI.
 
+## Local Development Notes
+
+- Local defaults are in `.env.dev`.
+- Override local values in `.env.dev.local` (git-ignored).
+- `just dev-server` sets `BACKUP_DB_PATH` to `tmp/server.db`.
+- `just dev-agent` sets `BACKUP_DATA_DIR` to `tmp/agent-data`.
+- `just dev-frontend` runs Vite with `/api` proxied to `localhost:8080`.
+
+Common dev commands:
+
+```bash
+just dev-server
+just dev-agent
+just dev-frontend
+just dev          # zellij layout for all services
+just dev-stop
+```
+
 ## Go Conventions
 - **No ORM** — raw SQL with `database/sql`, methods on `*DB` receiver
 - **SQLite driver** — `modernc.org/sqlite` (pure Go, no CGO)
@@ -76,6 +94,63 @@ Hooks run `gofmt` (format check) and `go vet` on staged Go files. They are inten
 - **Types** — shared API types in `src/types/api.ts`
 - **Components** — SFC with `<script setup lang="ts">`
 - **Styling** — Tailwind CSS utility classes
+
+## CI and PR Requirements
+
+Key workflows in `.github/workflows/`:
+
+- `ci.yml` — tests, fmt/vet checks, build, PR lint, and proto checks
+- `pr-label-check.yml` — enforces label policy on PRs
+- `release-drafter.yml` — maintains rolling draft release notes
+- `build-push.yml` — builds/pushes Docker images on `main` and tags
+
+PR label policy (enforced):
+
+- Exactly one `type/*` label
+- At least one `area/*` label
+- Optional `impact/*` labels for context
+
+PR checklist expectations:
+
+- Fill `.github/pull_request_template.md`
+- Complete the `release-note` fenced block
+- Use `NONE` for non-user-facing changes
+
+Recommended pre-PR validation:
+
+```bash
+just test
+just fmt
+just vet
+just lint
+```
+
+If proto changed:
+
+```bash
+just proto-gen
+just proto-lint
+just proto-breaking
+```
+
+## Release Workflow Notes
+
+- Squash merge is used; PR title becomes merge commit subject.
+- `release-drafter.yml` groups PRs into a draft release.
+- `refresh-release-draft.yml` can rebuild draft notes from PR `release-note` blocks (with optional AI summary).
+- Local helpers:
+
+```bash
+just release-notes
+just release-notes-polished
+```
+
+## Troubleshooting
+
+- If commands or tooling drift, start with `just --list`.
+- If generated code is stale, run `just proto-gen`.
+- If server build fails due to missing embedded assets, run `just build-frontend` (or create `server/internal/frontend/dist/index.html` stub for CI-like builds).
+- Reinstall hooks when needed: `lefthook install`.
 
 ## Key Design Decisions
 - Agent connects outbound to server (server is the only open port)
@@ -94,3 +169,5 @@ Hooks run `gofmt` (format check) and `go vet` on staged Go files. They are inten
 - `docs/multi-repo-strategy.md` — Independent backup strategy
 - `docs/agent-server-design.md` — Communication patterns and enrollment
 - `docs/open-questions.md` — Decided questions and version scope
+- `docs/workflow.md` — End-to-end contributor and release workflow
+- `docs/maintainer-guidelines.md` — Maintainer release and merge conventions


### PR DESCRIPTION
### What this PR does

PR title reminder (non-blocking): use a short, imperative, specific title. With squash merge, this title becomes the merge commit subject.

Optional maintainer hint for squash subject:

Suggested squash subject: docs: improve agent guidance and add dependabot skill references

Reference: [docs/maintainer-guidelines.md](docs/maintainer-guidelines.md)

Before this PR:
- Agent-facing contribution guidance was split across multiple places, with no root AGENTS.md.
- CLAUDE.md did not include the latest validated CI label policy and release-note workflow details.
- Dependabot skill references/examples were not consolidated in this branch target.

After this PR:
- Added root AGENTS.md with actionable setup, dev, test, build, CI, PR, and troubleshooting instructions for coding agents.
- Updated CLAUDE.md with CI/PR policy, release workflow notes, local dev environment behavior, and troubleshooting additions.
- Added Dependabot skill reference material and examples under .github/skills/dependabot for agent guidance coverage.

Fixes #
N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Chose documentation-first updates instead of behavior/code changes to improve contributor and agent effectiveness with low risk.
- Duplicated selected workflow guidance between AGENTS.md and CLAUDE.md for discoverability by different tools.

The following alternatives were considered:
- Keeping guidance only in README or workflow docs; rejected because agent tools typically look for AGENTS.md or CLAUDE.md first.
- Deferring updates until later; rejected because PR/release-note and label requirements are enforced and should be easy to find now.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

NONE

### Special notes for your reviewer

- This PR is documentation and skill-guidance focused.
- No runtime behavior changes are intended.
- Please validate wording consistency between AGENTS.md and CLAUDE.md.

### Labels

Please ensure this PR has:

- exactly one `type/*` label
- one or more `area/*` labels when relevant
- optional `impact/*` labels when they help release context

Type label guidance:

- choose the label that best matches the main reason this PR exists
- if a feature PR also includes docs/tests/refactors, keep `type/feature`
- if the main goal is efficiency, prefer `type/performance` over `type/refactor`

Reference: [docs/release-workflow-plan.md](docs/release-workflow-plan.md)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others
- [x] Labels: This PR has exactly one `type/*` label and appropriate `area/*` labels

### Release note

```release-note
Improve contributor and coding-agent documentation by adding a root AGENTS.md, updating CLAUDE.md with CI/PR and release workflow guidance, and adding Dependabot skill references/examples for repository automation guidance.
```
