### PR TITLE
ci: limit push-triggered CI to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
 
 permissions:


### PR DESCRIPTION
### What this PR does

PR title reminder (non-blocking): use a short, imperative, specific title. With squash merge, this title becomes the merge commit subject.

Optional maintainer hint for squash subject:

Suggested squash subject: ci: limit push-triggered CI to main

Reference: [docs/maintainer-guidelines.md](docs/maintainer-guidelines.md)

Before this PR:
- CI workflow push trigger matched all branches with branches: ["**"] in [.github/workflows/ci.yml](.github/workflows/ci.yml#L5), which ran push CI for every branch push.

After this PR:
- CI workflow push trigger is limited to main with branches: ["main"] in [.github/workflows/ci.yml](.github/workflows/ci.yml#L5), while pull_request triggers remain unchanged.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Pros: Reduces CI noise and resource usage from branch pushes when PR checks already cover validation.
- Cons: Non-PR branch pushes no longer run push-triggered CI.

The following alternatives were considered:
- Keep branches: ["**"] and accept broader CI execution.
- Add more granular branch patterns, which adds maintenance overhead without clear benefit for this change.

Links to places where the discussion took place: N/A

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.
- NONE

### Special notes for your reviewer

- This is a single-line workflow trigger change in [.github/workflows/ci.yml](.github/workflows/ci.yml#L5).

### Labels

Please ensure this PR has:

- exactly one `type/*` label
- one or more `area/*` labels when relevant
- optional `impact/*` labels when they help release context

Type label guidance:

- choose the label that best matches the main reason this PR exists
- if a feature PR also includes docs/tests/refactors, keep `type/feature`
- if the main goal is efficiency, prefer `type/performance` over `type/refactor`

Reference: [docs/release-workflow-plan.md](docs/release-workflow-plan.md)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via /gh-pr-review, gh pr diff, or GitHub UI) before requesting review from others
- [x] Labels: This PR has exactly one type/* label and appropriate area/* labels

### Release note

```release-note
NONE
```
