### PR TITLE
chore(ci): remove redundant workflow path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,26 +32,23 @@ jobs:
             server:
               - 'server/**'
               - 'proto/**'
-              - '.github/workflows/**'
               - '.golangci.yml'
               - 'justfile'
             agent:
               - 'agent/**'
               - 'proto/**'
-              - '.github/workflows/**'
+              - '.golangci.yml'
+              - 'justfile'
               - '.golangci.yml'
               - 'justfile'
             frontend:
               - 'frontend/**'
-              - '.github/workflows/**'
             proto:
               - 'proto/**'
-              - '.github/workflows/**'
             go:
               - 'server/**'
               - 'agent/**'
               - 'proto/**'
-              - '.github/workflows/**'
               - '.golangci.yml'
               - 'justfile'
             build:
@@ -59,7 +56,6 @@ jobs:
               - 'agent/**'
               - 'frontend/**'
               - 'proto/**'
-              - '.github/workflows/**'
               - 'docker/**'
               - 'justfile'
 


### PR DESCRIPTION
### What this PR does

PR title reminder (non-blocking): use a short, imperative, specific title. With squash merge, this title becomes the merge commit subject.

Optional maintainer hint for squash subject:

Suggested squash subject: chore(ci): remove redundant workflow path filters

Reference: [docs/maintainer-guidelines.md](docs/maintainer-guidelines.md)

Before this PR:
Workflow path entries were duplicated across multiple component change-detection filters in CI.

After this PR:
Redundant `.github/workflows/**` entries are removed from component-specific filters to avoid unnecessary job fan-out on workflow-only changes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
The workflow relies on dedicated workflow-change handling instead of repeating workflow paths under each component filter, which reduces duplicate triggers while preserving intended CI coverage.

The following alternatives were considered:
Keeping the duplicated workflow path entries was considered, but it keeps over-triggering jobs that are unrelated to workflow-only changes.

Links to places where the discussion took place: N/A <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.
N/A

### Special notes for your reviewer

<!-- optional -->
Please confirm workflow-only edits still trigger the expected CI checks without unnecessary component-specific jobs.

### Labels

Please ensure this PR has:

- exactly one `type/*` label
- one or more `area/*` labels when relevant
- optional `impact/*` labels when they help release context

Type label guidance:

- choose the label that best matches the main reason this PR exists
- if a feature PR also includes docs/tests/refactors, keep `type/feature`
- if the main goal is efficiency, prefer `type/performance` over `type/refactor`

Reference: [docs/release-workflow-plan.md](docs/release-workflow-plan.md)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others
- [x] Labels: This PR has exactly one `type/*` label and appropriate `area/*` labels

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
